### PR TITLE
Refs/heads/iteration3 feature deduplicate task for folders

### DIFF
--- a/src/postprocess.py
+++ b/src/postprocess.py
@@ -54,27 +54,49 @@ def main():
         print(f"Postprocessing complete. Output saved to: {output_file}")
 
     elif os.path.isdir(input_path):
-        # PDF processing
-        pdf_processor = PDFPostProcessor(input_path)
+    # PDF processing
+        subdirs = [os.path.join(input_path, d) for d in os.listdir(input_path) if os.path.isdir(os.path.join(input_path, d))]
+        if subdirs:
+            # Iterate over each subdirectory
+            for subdir in subdirs:
+                print(f"Processing PDFs in subdirectory: {subdir}")
+                pdf_processor = PDFPostProcessor(subdir)
 
-        if args.tasks:
-            for task_name in args.tasks:
-                if task_name in PDFPostProcessor.task_registry:
-                    print(f"Performing PDF task: {task_name}")
-                    task_func_name = PDFPostProcessor.task_registry[task_name]['func']
-                    task_func = getattr(pdf_processor, task_func_name)
-                    task_func()
+                if args.tasks:
+                    for task_name in args.tasks:
+                        if task_name in PDFPostProcessor.task_registry:
+                            print(f"Performing PDF task: {task_name} on {subdir}")
+                            task_func_name = PDFPostProcessor.task_registry[task_name]['func']
+                            task_func = getattr(pdf_processor, task_func_name)
+                            task_func()
+                        else:
+                            print(f"Task '{task_name}' not recognized for PDFs. Skipping.")
                 else:
-                    print(f"Task '{task_name}' not recognized for PDFs. Skipping.")
+                    print("No PDF tasks specified. Exiting.")
+                    exit(1)
+
+            else:
+                # NO subdirectories, process the input directory directly
+                pdf_processor = PDFPostProcessor(input_path)
+
+                if args.tasks:
+                    for task_name in args.tasks:
+                        if task_name in PDFPostProcessor.task_registry:
+                            print(f"Performing PDF task: {task_name}")
+                            task_func_name = PDFPostProcessor.task_registry[task_name]['func']
+                            task_func = getattr(pdf_processor, task_func_name)
+                            task_func()
+                        else:
+                            print(f"Task '{task_name}' not recognized for PDFs. Skipping.")
+                else:
+                    print("No PDF tasks specified. Exiting.")
+                    exit(1)
+
+            print("PDF postprocessing complete.")
+            
         else:
-            print("No PDF tasks specified. Exiting.")
+            print("Invalid input path. Please provide a valid Excel file or directory containing PDFs.")
             exit(1)
-
-        print("PDF postprocessing complete.")
-
-    else:
-        print("Invalid input path. Please provide a valid Excel file or directory containing PDFs.")
-        exit(1)
 
 if __name__ == '__main__':
     main()

--- a/src/postprocess.py
+++ b/src/postprocess.py
@@ -75,28 +75,28 @@ def main():
                     print("No PDF tasks specified. Exiting.")
                     exit(1)
 
-            else:
-                # NO subdirectories, process the input directory directly
-                pdf_processor = PDFPostProcessor(input_path)
+        else:
+            # NO subdirectories, process the input directory directly
+            pdf_processor = PDFPostProcessor(input_path)
 
-                if args.tasks:
-                    for task_name in args.tasks:
-                        if task_name in PDFPostProcessor.task_registry:
-                            print(f"Performing PDF task: {task_name}")
-                            task_func_name = PDFPostProcessor.task_registry[task_name]['func']
-                            task_func = getattr(pdf_processor, task_func_name)
-                            task_func()
-                        else:
-                            print(f"Task '{task_name}' not recognized for PDFs. Skipping.")
-                else:
-                    print("No PDF tasks specified. Exiting.")
-                    exit(1)
+            if args.tasks:
+                for task_name in args.tasks:
+                    if task_name in PDFPostProcessor.task_registry:
+                        print(f"Performing PDF task: {task_name}")
+                        task_func_name = PDFPostProcessor.task_registry[task_name]['func']
+                        task_func = getattr(pdf_processor, task_func_name)
+                        task_func()
+                    else:
+                        print(f"Task '{task_name}' not recognized for PDFs. Skipping.")
+            else:
+                print("No PDF tasks specified. Exiting.")
+                exit(1)
 
             print("PDF postprocessing complete.")
             
-        else:
-            print("Invalid input path. Please provide a valid Excel file or directory containing PDFs.")
-            exit(1)
+    else:
+        print("Invalid input path. Please provide a valid Excel file or directory containing PDFs.")
+        exit(1)
 
 if __name__ == '__main__':
     main()

--- a/src/postprocess.py
+++ b/src/postprocess.py
@@ -75,23 +75,23 @@ def main():
                     print("No PDF tasks specified. Exiting.")
                     exit(1)
 
-            # NO subdirectories, process the input directory directly
-            pdf_processor = PDFPostProcessor(input_path)
+        # After processing subdirectories, check input base directory.
+        pdf_processor = PDFPostProcessor(input_path)
 
-            if args.tasks:
-                for task_name in args.tasks:
-                    if task_name in PDFPostProcessor.task_registry:
-                        print(f"Performing PDF task: {task_name}")
-                        task_func_name = PDFPostProcessor.task_registry[task_name]['func']
-                        task_func = getattr(pdf_processor, task_func_name)
-                        task_func()
-                    else:
-                        print(f"Task '{task_name}' not recognized for PDFs. Skipping.")
-            else:
-                print("No PDF tasks specified. Exiting.")
-                exit(1)
+        if args.tasks:
+            for task_name in args.tasks:
+                if task_name in PDFPostProcessor.task_registry:
+                    print(f"Performing PDF task: {task_name}")
+                    task_func_name = PDFPostProcessor.task_registry[task_name]['func']
+                    task_func = getattr(pdf_processor, task_func_name)
+                    task_func()
+                else:
+                    print(f"Task '{task_name}' not recognized for PDFs. Skipping.")
+        else:
+            print("No PDF tasks specified. Exiting.")
+            exit(1)
 
-            print("PDF postprocessing complete.")
+        print("PDF postprocessing complete.")
             
     else:
         print("Invalid input path. Please provide a valid Excel file or directory containing PDFs.")

--- a/src/postprocess.py
+++ b/src/postprocess.py
@@ -75,7 +75,6 @@ def main():
                     print("No PDF tasks specified. Exiting.")
                     exit(1)
 
-        else:
             # NO subdirectories, process the input directory directly
             pdf_processor = PDFPostProcessor(input_path)
 

--- a/src/postprocess_utils.py
+++ b/src/postprocess_utils.py
@@ -424,19 +424,17 @@ class PDFPostProcessor:
 
         # Gather user inputs
         if self.__class__.acc_input is None:
-            acc_input = input("Please provide an example of the account number. (e.g., '44-1234'):\n")
-        else:
-            acc_input = self.__class__.acc_input
+            self.__class__.acc_input = input("Please provide an example of the account number. (e.g., '44-1234'):\n")
 
         if self.__class__.state_input is None:
-            state_input = input("Please provide an example of the statement number with prefix sentence. (e.g., 'Statement no. 12'): \n")
-        else:
-            state_input = self.__class__.state_input
-            
+            self.__class__.state_input = input("Please provide an example of the statement number with prefix sentence. (e.g., 'Statement no. 12'): \n")
+
         if self.__class__.date_input is None:
-            date_input = input("Please provide an example of the statement start date. (e.g., '12 NOV 2023'): \n")
-        else:
-            date_input = self.__class__.date_input
+            self.__class__.date_input = input("Please provide an example of the statement start date. (e.g., '12 NOV 2023'): \n")
+        
+        acc_input = self.__class__.acc_input
+        state_input = self.__class__.state_input
+        date_input = self.__class__.date_input
 
         # regex inputs
         acc_pattern = self.generate_regex_from_value_example(acc_input)

--- a/src/postprocess_utils.py
+++ b/src/postprocess_utils.py
@@ -114,6 +114,11 @@ class PDFPostProcessor:
         # Add more tasks here as needed
     }
 
+    # Class variables
+    acc_input = None
+    state_input = None
+    date_input = None
+
     def __init__(self, input_folder):
         self.input_folder = input_folder
         self.pdf_files = list(Path(input_folder).glob("*.pdf"))
@@ -359,9 +364,12 @@ class PDFPostProcessor:
         Add statement start date as prefix to PDF filenames for chronological ordering.
         """
         # NOTE: Need to gain insight into which date target is the "correct" date.
-        date_example = input("Please input an example of the start date format. (e.g., '02-FEB-2024', '04-30-2019'):\n")
+        if self.__class__.date_input is None:
+            date_input = input("Please input an example of the start date format. (e.g., '02-FEB-2024', '04-30-2019'):\n")
+        else: 
+            date_input = self.__class__.date_input
         # Develop regex pattern from input example
-        pattern = self.generate_regex_from_value_example(date_example)
+        pattern = self.generate_regex_from_value_example(date_input)
         # Insert pattern into extract_value_from_pdf and output
         if not pattern:
             print("Pattern generation failed. Exiting task.")
@@ -370,6 +378,7 @@ class PDFPostProcessor:
             pdf_path = str(pdf_file)
             date_str = self.extract_statement_start_date(pdf_path, pattern)
             if date_str:
+                # TODO: Move this function into the extraction method, to match statement number extraction method
                 date_prefix = self.format_date(date_str)
                 # Determine new file name
                 new_filename = (f"{date_prefix}-{pdf_file.name}")
@@ -414,9 +423,20 @@ class PDFPostProcessor:
         counter = 0
 
         # Gather user inputs
-        acc_input = input("Please provide an example of the account number. (e.g., '44-1234'):\n")
-        state_input = input("Please provide an example of the statement number. (e.g., 'Statement no. 12'): \n")
-        date_input = input("Please provide an example of the statement start date. (e.g., '12 NOV 2023'): \n")
+        if self.__class__.acc_input is None:
+            acc_input = input("Please provide an example of the account number. (e.g., '44-1234'):\n")
+        else:
+            acc_input = self.__class__.acc_input
+
+        if self.__class__.state_input is None:
+            state_input = input("Please provide an example of the statement number with prefix sentence. (e.g., 'Statement no. 12'): \n")
+        else:
+            state_input = self.__class__.state_input
+            
+        if self.__class__.date_input is None:
+            date_input = input("Please provide an example of the statement start date. (e.g., '12 NOV 2023'): \n")
+        else:
+            date_input = self.__class__.date_input
 
         # regex inputs
         acc_pattern = self.generate_regex_from_value_example(acc_input)


### PR DESCRIPTION
The code provided to test worked pretty much as is. I only added two things:

1. Changed the class variable checker to check each item individually, so it only asks the user to input the missing variables rather than all 3 if any of them are missing. Not too strong in my knowledge of Class Variables to know if this is a mistake.
2. Adjusted the sub directory loop such that when it finishes all the subdirectories, it checks the base directory for any leftover items. The original loop would miss items sitting in the input directory if subdirectories existed. It can still compute a folder with no subdirectories without error.