### PR TITLE
71 standardise argument options and help menu

### DIFF
--- a/src/postprocess.py
+++ b/src/postprocess.py
@@ -11,7 +11,6 @@ def main():
     parser = argparse.ArgumentParser(
         description=f'This script provides a variety of postprocessing tasks.\n\n**AVAILABLE EXCEL TASKS:\n{excel_task_help}\n\n**AVAILABLE PDF TASKS:\n{pdf_task_help}',
         formatter_class=argparse.RawTextHelpFormatter,
-
         epilog='''Example: python src/postprocess.py -i PATH/TO/PDFS -t categorise_by_value'''
     )
 
@@ -27,7 +26,7 @@ def main():
         type=str, 
         nargs='+', 
         help='List of post-processing tasks to perform.'
-        )
+    )
     
     args = parser.parse_args()
 

--- a/src/postprocess.py
+++ b/src/postprocess.py
@@ -9,7 +9,7 @@ def main():
 
     # Parse command-line arguments using RawTextHelpFormatter to preserve formatting
     parser = argparse.ArgumentParser(
-        description=f'Postprocessing tasks.\n\n**AVAILABLE EXCEL TASKS:\n{excel_task_help}\n\n**AVAILABLE PDF TASKS:\n{pdf_task_help}',
+        description=f'This script provides a variety of postprocessing tasks.\n\n**AVAILABLE EXCEL TASKS:\n{excel_task_help}\n\n**AVAILABLE PDF TASKS:\n{pdf_task_help}',
         formatter_class=argparse.RawTextHelpFormatter,
 
         epilog='''Example: python src/postprocess.py -i PATH/TO/PDFS -t categorise_by_value'''

--- a/src/postprocess.py
+++ b/src/postprocess.py
@@ -10,7 +10,9 @@ def main():
     # Parse command-line arguments using RawTextHelpFormatter to preserve formatting
     parser = argparse.ArgumentParser(
         description=f'Postprocessing tasks.\n\n**AVAILABLE EXCEL TASKS:\n{excel_task_help}\n\n**AVAILABLE PDF TASKS:\n{pdf_task_help}',
-        formatter_class=argparse.RawTextHelpFormatter
+        formatter_class=argparse.RawTextHelpFormatter,
+
+        epilog='''Example: python src/postprocess.py -i PATH/TO/PDFS -t categorise_by_value'''
     )
 
     parser.add_argument(
@@ -21,7 +23,7 @@ def main():
         )
     
     parser.add_argument(
-        '--tasks', 
+        '-t', '--tasks', 
         type=str, 
         nargs='+', 
         help='List of post-processing tasks to perform.'

--- a/src/preprocess.py
+++ b/src/preprocess.py
@@ -9,12 +9,14 @@ from count_pdfs import PDFCounter
 def main():
     # Parse command-line arguments
     parser = argparse.ArgumentParser(
-        description='''PDF Preprocessing Script.
+        description='''
+        PDF Preprocessing Script.
         
         This script splits PDF files containing multiple statements into individual files to prepare them for processing. 
         It creates a folder within the --input folder based on the --name given.
         Within this folder it creates necessary folders, counts PDFs before and after splitting them, saves the counts to Excel files,
         and stores the split files.''',
+        formatter_class=argparse.RawDescriptionHelpFormatter,
         
         epilog='''Example: python src/preprocess.py -i PATH/TO/PDFS -n statement_run_1 -t "St. George - Bank Statement"'''
     )

--- a/src/preprocess.py
+++ b/src/preprocess.py
@@ -16,8 +16,7 @@ def main():
         It creates a folder within the --input folder based on the --name given.
         Within this folder it creates necessary folders, counts PDFs before and after splitting them, saves the counts to Excel files,
         and stores the split files.''',
-        formatter_class=argparse.RawDescriptionHelpFormatter,
-        
+        formatter_class=argparse.RawDescriptionHelpFormatter,        
         epilog='''Example: python src/preprocess.py -i PATH/TO/PDFS -n statement_run_1 -t "St. George - Bank Statement"'''
     )
 
@@ -41,7 +40,6 @@ def main():
         type=str,
         required=True,
         help='Type of file to process. See YAML for options.'
-
     )
     
     args = parser.parse_args()

--- a/src/process.py
+++ b/src/process.py
@@ -23,9 +23,8 @@ def main():
         This script takes a preprocessed folder of PDFs each containing individual statements and extracts the information into an excel file.
         The --input requires the user to specify what --type of statement is being accessed. The available types can be found in the type_models.yaml.
         The --config argument is pre-defined but can be changed if required.''',
-
-        formatter_class=argparse.RawDescriptionHelpFormatter,                             
-        epilog = '''Example: python src/process.py --i PATH/TO/PREPROCESSED PDFS --t "AMEX - Card Statement"'''
+        formatter_class=argparse.RawDescriptionHelpFormatter, 
+        epilog = '''Example: python src/process.py -i PATH/TO/PDFS -t "AMEX - Card Statement"'''
         )
     
     parser.add_argument(

--- a/src/process.py
+++ b/src/process.py
@@ -20,31 +20,33 @@ def main():
         description='''PDF Processing Script
                                      
         This script takes a preprocessed folder of PDFs each containing individual statements and extracts the information into an excel file.
-        The input requires the user to specify what type of statement is being accessed. The available types can be found in the type_models.yaml.
-        The config argument is pre-defined but can be changed if required.
-        ''',
+        The --input requires the user to specify what --type of statement is being accessed. The available types can be found in the type_models.yaml.
+        The --config argument is pre-defined but can be changed if required.''',
                                      
-        epilog = '''Example: python src/process.py --input PATH/TO/PREPROCESSED PDFS --type "AMEX - Card Statement"
-        '''
+        epilog = '''Example: python src/process.py --i PATH/TO/PREPROCESSED PDFS --t "AMEX - Card Statement"'''
         )
+    
     parser.add_argument(
-        '--input', 
+        '-i', '--input', 
         type=str, 
         required=True, 
         help='Path to the input folder containing preprocessed PDFs'
         )
+    
     parser.add_argument(
-        '--config_type', 
+        '-c', '--config_type', 
         type=str, 
         default='/config/type_models.yaml', 
         help='Path to the statement types configuration YAML file'
         )
+    
     parser.add_argument(
-        '--type', 
+        '-t', '--type', 
         type=str, 
         required=True, 
         help='Name of the statement type to use'
-        )
+    )
+    
     args = parser.parse_args()
 
     input_dir = args.input

--- a/src/process.py
+++ b/src/process.py
@@ -17,12 +17,14 @@ def main():
 
     # Parse command-line arguments
     parser = argparse.ArgumentParser(
-        description='''PDF Processing Script
+        description='''
+        PDF Processing Script
                                      
         This script takes a preprocessed folder of PDFs each containing individual statements and extracts the information into an excel file.
         The --input requires the user to specify what --type of statement is being accessed. The available types can be found in the type_models.yaml.
         The --config argument is pre-defined but can be changed if required.''',
-                                     
+
+        formatter_class=argparse.RawDescriptionHelpFormatter,                             
         epilog = '''Example: python src/process.py --i PATH/TO/PREPROCESSED PDFS --t "AMEX - Card Statement"'''
         )
     

--- a/src/raw_process.py
+++ b/src/raw_process.py
@@ -17,20 +17,24 @@ def main():
 
     # Parse command-line arguments
     parser = argparse.ArgumentParser(
-        description='''PDF Processing Script
+        description='''\
+        PDF Processing Script
                                      
         This script takes a preprocessed folder of PDFs each containing individual statements and extracts the RAW DATA into an excel file.
-        ''',
+        It creates a folder within the --input folder and saves the excel into that folder.
+        The excel is saved as "extracted-data.xlsx"''',
+        formatter_class=argparse.RawDescriptionHelpFormatter,
                                      
-        epilog = '''Example: python src/raw_process.py --input PATH/TO/PREPROCESSED PDFS
-        '''
+        epilog = '''Example: python src/raw_process.py -i PATH/TO/PDFS'''
         )
+    
     parser.add_argument(
-        '--input', 
+        '-i', '--input', 
         type=str, 
         required=True, 
         help='Path to the input folder containing preprocessed PDFs'
         )
+    
     args = parser.parse_args()
 
     input_dir = args.input

--- a/src/raw_process.py
+++ b/src/raw_process.py
@@ -22,9 +22,8 @@ def main():
                                      
         This script takes a preprocessed folder of PDFs each containing individual statements and extracts the RAW DATA into an excel file.
         It creates a folder within the --input folder and saves the excel into that folder.
-        The excel is saved as "extracted-data.xlsx"''',
-        formatter_class=argparse.RawDescriptionHelpFormatter,
-                                     
+        The excel is saved as "extracted-data.xlsx"''',        
+        formatter_class=argparse.RawDescriptionHelpFormatter,                                     
         epilog = '''Example: python src/raw_process.py -i PATH/TO/PDFS'''
         )
     
@@ -33,7 +32,7 @@ def main():
         type=str, 
         required=True, 
         help='Path to the input folder containing preprocessed PDFs'
-        )
+    )
     
     args = parser.parse_args()
 


### PR DESCRIPTION
Changed the argument options and help menu to be uniform across the following scripts:

- preprocess.py
- process.py
- raw_process.py
- postprocess.py

Specifically added single letter options for each argument and adjusted the description and epilog to contain consistent formatting that is easier for users to read.
Adjusted whitespace to be more consistent.